### PR TITLE
Missing #include in Rom.h that prevents compilation

### DIFF
--- a/src/Rom.h
+++ b/src/Rom.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class Rom
 {


### PR DESCRIPTION
Hello,

I was messing with this application and as there were no releases I went to compile it myself. It got stuck early on in compilation but was given an error that basically told me to add this line. Upon doing so the compilation finished successfully and the application ran as expected. Since I already had the edit in place I decided to make a quick PR for the fix to help out.